### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,16 +10,16 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 
-MiDispositivoMIDI_V3  KEYWORD2
-loop  				  KEYWORD2
-initializeLEDs  	  KEYWORD2
-setMidiNotes    	  KEYWORD2
-setMidiVeloc   	  	  KEYWORD2
-setOnColors   	      KEYWORD2
-setOffColors  		  KEYWORD2
-setPixelColor  		  KEYWORD2
-setInterrupt   		  KEYWORD2
-setMidiChannel 		  KEYWORD2
+MiDispositivoMIDI_V3	KEYWORD2
+loop	KEYWORD2
+initializeLEDs	KEYWORD2
+setMidiNotes	KEYWORD2
+setMidiVeloc	KEYWORD2
+setOnColors	KEYWORD2
+setOffColors	KEYWORD2
+setPixelColor	KEYWORD2
+setInterrupt	KEYWORD2
+setMidiChannel	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords