### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=MiDispositivoMIVI is a MIDI controller based on Arduino. This library 
 category=Other
 url=https://github.com/Bananut-Electronics/
 architectures=*
+depends=Adafruit NeoPixel, MIDIUSB, TimerOne


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install the dependencies during installation of this library.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format